### PR TITLE
Tensorboard (#36)

### DIFF
--- a/model.py
+++ b/model.py
@@ -50,6 +50,7 @@ class Model():
                 [tf.ones([args.batch_size * args.seq_length])],
                 args.vocab_size)
         self.cost = tf.reduce_sum(loss) / args.batch_size / args.seq_length
+        tf.summary.scalar("cost", self.cost)
         self.final_state = last_state
         self.lr = tf.Variable(0.0, trainable=False)
         tvars = tf.trainable_variables()

--- a/train.py
+++ b/train.py
@@ -81,7 +81,12 @@ def train(args):
 
     model = Model(args)
 
+    batch_pointer = tf.Variable(0, name="batch_pointer", trainable=False)
+    merged = tf.summary.merge_all()
+    train_writer = tf.summary.FileWriter('logs')
+
     with tf.Session() as sess:
+        train_writer.add_graph(sess.graph)
         tf.global_variables_initializer().run()
         saver = tf.train.Saver(tf.global_variables())
         # restore model
@@ -90,22 +95,33 @@ def train(args):
         for e in range(args.num_epochs):
             sess.run(tf.assign(model.lr, args.learning_rate * (args.decay_rate ** e)))
             data_loader.reset_batch_pointer()
+            if args.init_from is None:
+                assign_op = batch_pointer.assign(0)
+                sess.run(assign_op)
             state = sess.run(model.initial_state)
-            for b in range(data_loader.num_batches):
+            if args.init_from is not None:
+                data_loader.pointer = batch_pointer.eval()
+                args.init_from = None
+            for b in range(data_loader.pointer, data_loader.num_batches):
                 start = time.time()
                 x, y = data_loader.next_batch()
                 feed = {model.input_data: x, model.targets: y, model.initial_state: state}
-                train_loss, state, _ = sess.run([model.cost, model.final_state, model.train_op], feed)
+                summary, train_loss, state, _ = sess.run([merged, model.cost, model.final_state, model.train_op], feed)
+                train_writer.add_summary(summary, e * data_loader.num_batches + b)
+                assign_op = batch_pointer.assign(data_loader.pointer)
+                sess.run(assign_op)
                 end = time.time()
-                print("{}/{} (epoch {}), train_loss = {:.3f}, time/batch = {:.3f}" \
-                    .format(e * data_loader.num_batches + b,
-                            args.num_epochs * data_loader.num_batches,
-                            e, train_loss, end - start))
+                if (e * data_loader.num_batches + b) % args.batch_size == 0:
+                    print("{}/{} (epoch {}), train_loss = {:.3f}, time/batch = {:.3f}" \
+                        .format(e * data_loader.num_batches + b,
+                                args.num_epochs * data_loader.num_batches,
+                                e, train_loss, end - start))
                 if (e * data_loader.num_batches + b) % args.save_every == 0 \
                         or (e==args.num_epochs-1 and b == data_loader.num_batches-1): # save for the last result
                     checkpoint_path = os.path.join(args.save_dir, 'model.ckpt')
                     saver.save(sess, checkpoint_path, global_step = e * data_loader.num_batches + b)
                     print("model saved to {}".format(checkpoint_path))
+        train_writer.close()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* Fix Spelling

Signed-off-by: Norman Heckscher <norman.heckscher@gmail.com>

* Log cost to TensorBoard

Signed-off-by: Norman Heckscher <norman.heckscher@gmail.com>

* Fix typo

Signed-off-by: Norman Heckscher <norman.heckscher@gmail.com>

* Add graph to TensorBoard

Signed-off-by: Norman Heckscher <norman.heckscher@gmail.com>

* Resume from last saved state within epoch.

Previously the last saved state would only resume from the beginning of an epoch with saved network settings. The changes in this code allow to resume from the last saved state within the epoc at the batch level. This should prevent overfitting by biasing the first sets of batches within an epoch that is saved and resumed.

Signed-off-by: Norman Heckscher <norman.heckscher@gmail.com>

* Remove redundant line

Signed-off-by: Norman Heckscher <norman.heckscher@gmail.com>